### PR TITLE
Ignore .gitignore file while diffing expected text output

### DIFF
--- a/test-high/run-tests.sh
+++ b/test-high/run-tests.sh
@@ -85,7 +85,7 @@ rm -f actual/*
 
 find actual -type f -size -80c -delete
 
-if diff -ru expected actual
+if diff -ru -x .gitignore expected actual
 then
     echo All tests succeeded.
 else


### PR DESCRIPTION
Fixes

```
cd test-high; make
make[1]: Entering directory '/havana/t/p/pcg-cpp/test-high'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/havana/t/p/pcg-cpp/test-high'
cd sample; make
make[1]: Entering directory '/havana/t/p/pcg-cpp/sample'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/havana/t/p/pcg-cpp/sample'
cd test-high; make test
make[1]: Entering directory '/havana/t/p/pcg-cpp/test-high'
sh run-tests.sh
Performing a quick sanity check...
Only in expected: .gitignore

ERROR: Some tests failed.
make[1]: Leaving directory '/havana/t/p/pcg-cpp/test-high'
```
