### PR TITLE
Allow compilation without RTTI.

### DIFF
--- a/include/pcg_extras.hpp
+++ b/include/pcg_extras.hpp
@@ -613,6 +613,8 @@ public:
 //
 // to print out my_foo_type_t (or its concrete type if it is a synonym)
 
+#if __cpp_rtti || __GXX_RTTI
+
 template <typename T>
 struct printable_typename {};
 
@@ -632,6 +634,8 @@ std::ostream& operator<<(std::ostream& out, printable_typename<T>) {
     out << implementation_typename;
     return out;
 }
+
+#endif  // __cpp_rtti || __GXX_RTTI
 
 } // namespace pcg_extras
 


### PR DESCRIPTION
I'm looking to use this in a codebase that compiles with -fno-rtti, and putting the offending struct and function behind a flag is all that is needed. I don't know if I have to modify any of your demos.
