### PR TITLE
Use static_assert when possible.

### DIFF
--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -674,9 +674,15 @@ itype operator-(const engine<xtype,itype,
                                output_mixin,output_previous,
                                stream_mixin_rhs, multiplier_mixin_rhs>& rhs)
 {
+#if __cplusplus >= 201103L
+    static_assert(lhs.multiplier() == rhs.multiplier() &&
+                  lhs.increment() == rhs.increment(),
+                  "Incomparable generators");
+#else
     if (lhs.multiplier() != rhs.multiplier()
         || lhs.increment() != rhs.increment())
         throw std::logic_error("incomparable generators");
+#endif
     return rhs.distance(lhs.state_);
 }
 


### PR DESCRIPTION
There is only one `throw` in the code and it can be replaced with a `static_assert`. This patch will make PCG compatible with `-fno-exceptions`.