### PR TITLE
Fix stack overflow in inequality operator.

### DIFF
--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -1375,7 +1375,7 @@ inline bool operator!=(const extended<table_pow2, advance_pow2,
                        const extended<table_pow2, advance_pow2,
                                       baseclass, extvalclass, kdd>& rhs)
 {
-    return lhs != rhs;
+    return !operator==(lhs, rhs);
 }
 
 template <typename CharT, typename Traits,


### PR DESCRIPTION
The inequality operator for `extended` invokes itself, overflowing the stack. Instead, negate the equality operator.