### PR TITLE
Fix {i,o}stream support for pcg128_t

### DIFF
--- a/include/pcg_extras.hpp
+++ b/include/pcg_extras.hpp
@@ -115,11 +115,21 @@ namespace pcg_extras {
  *
  * This code provides enough functionality to print 128-bit ints in decimal
  * and zero-padded in hex.  It's not a full-featured implementation.
+ *
+ * Note that we cannot simply define operator<< implementations,
+ * because pcg128_t is (sometimes!) a typedef; Koenig lookup on typedefs
+ * looks at the resolved type, which is __uint128_t in the global namespace.
  */
+
+template <typename CharT, typename Traits, typename T>
+std::basic_ostream<CharT, Traits>&
+Output(std::basic_ostream<CharT, Traits>& out, const T &t) {
+  return out << t;
+}
 
 template <typename CharT, typename Traits>
 std::basic_ostream<CharT,Traits>&
-operator<<(std::basic_ostream<CharT,Traits>& out, pcg128_t value)
+Output(std::basic_ostream<CharT,Traits>& out, pcg128_t value)
 {
     auto desired_base = out.flags() & out.basefield;
     bool want_hex = desired_base == out.hex;
@@ -161,9 +171,15 @@ operator<<(std::basic_ostream<CharT,Traits>& out, pcg128_t value)
     return out << pos;
 }
 
+template <typename CharT, typename Traits, typename T>
+std::basic_istream<CharT, Traits>&
+Input(std::basic_istream<CharT, Traits>& in, T &t) {
+  return in >> t;
+}
+
 template <typename CharT, typename Traits>
 std::basic_istream<CharT,Traits>&
-operator>>(std::basic_istream<CharT,Traits>& in, pcg128_t& value)
+Input(std::basic_istream<CharT,Traits>& in, pcg128_t& value)
 {
     typename std::basic_istream<CharT,Traits>::sentry s(in);
 

--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -561,15 +561,17 @@ operator<<(std::basic_ostream<CharT,Traits>& out,
     auto space = out.widen(' ');
     auto orig_fill = out.fill();
 
-    out << rng.multiplier() << space
-        << rng.increment() << space
-        << rng.state_;
+    pcg_extras::Output(out, rng.multiplier());
+    out << space;
+    pcg_extras::Output(out, rng.increment());
+    out << space;
+    pcg_extras::Output(out, rng.state_);
+    out << space;
 
     out.flags(orig_flags);
     out.fill(orig_fill);
     return out;
 }
-
 
 template <typename CharT, typename Traits,
           typename xtype, typename itype,
@@ -584,8 +586,9 @@ operator>>(std::basic_istream<CharT,Traits>& in,
     auto orig_flags = in.flags(std::ios_base::dec | std::ios_base::skipws);
 
     itype multiplier, increment, state;
-    in >> multiplier >> increment >> state;
-
+    pcg_extras::Input(in, multiplier);
+    pcg_extras::Input(in, increment);
+    pcg_extras::Input(in, state);
     if (!in.fail()) {
         bool good = true;
         if (multiplier != rng.multiplier()) {

--- a/test-high/pcg-test.cpp
+++ b/test-high/pcg-test.cpp
@@ -30,6 +30,7 @@
 #include <cassert>
 #include <climits>
 #include <iostream>
+#include <sstream>
 #include <iomanip>
 #include <algorithm>
 #include <numeric>
@@ -139,8 +140,9 @@ int main(int argc, char** argv)
         printf("  Rolls:");
         for (int i = 0; i < 33; ++i)
             cout << " " << (uint32_t(rng(6)) + 1);
-        cout << "\n   -->   rolling dice used " 
-             << (rng - rng_copy) << " random numbers" << endl;
+        cout << "\n   -->   rolling dice used "
+             << static_cast<size_t>(rng - rng_copy)
+             << " random numbers" << endl;
 
         /* Deal some cards using pcg_extras::shuffle, which follows
          * the algorithm for shuffling that most programmers would expect.
@@ -166,6 +168,13 @@ int main(int argc, char** argv)
         
         cout << "\n" << endl;
     }
+
+    // Ensure that the input/output functions work.
+    std::stringstream ss;
+    ss << rng;
+    RNG from_string;
+    ss >> from_string;
+    assert(from_string == rng);
 
     return 0;
 }


### PR DESCRIPTION
We defined operator{<<,>>} for pcg128_t in pcg_extras, assuming Koenig
lookup would find these as needed.  This isn't actually true, because
pcg128_t is a typedef, and Koenig lookup doesn't apply to the
namespaces of typedefs.  We would need to define those operators in
the global namespace; that's a bad idea.

Instead, work around it.  Define explicit Input and Output functions
in the namespace, which in turn default to operator<< and operator>>
if they need to, and explicitly use them in engine printing/parsing
functions.