### PR TITLE
#fix for Visual Studio Compiler but now G++ doesn't work

### DIFF
--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -1204,7 +1204,7 @@ public:
         return baseclass::period_pow2() + table_size*extvalclass::period_pow2();
     }
 
-    __attribute__((always_inline)) result_type operator()()
+    _forceinline result_type operator()()
     {
         result_type rhs = get_extended_value();
         result_type lhs = this->baseclass::operator()();

--- a/include/pcg_uint128.hpp
+++ b/include/pcg_uint128.hpp
@@ -63,7 +63,7 @@
         #define PCG_LITTLE_ENDIAN 1
     #elif __BIG_ENDIAN__ || _BIG_ENDIAN
         #define PCG_LITTLE_ENDIAN 0
-    #elif __x86_64 || __x86_64__ || __i386 || __i386__
+    #elif __x86_64 || __x86_64__ || __i386 || __i386__ || _M_AMD64 || _M_IX86
         #define PCG_LITTLE_ENDIAN 1
     #elif __powerpc__ || __POWERPC__ || __ppc__ || __PPC__ \
           || __m68k__ || __mc68000__


### PR DESCRIPTION
1. - changed __attribute__(always_inline) macro with _forceinle which is the visual c++ compiler specific version of the same macro.
2. - added  _M_AMD64 and _M_IX86 macros (again visual c++ specific macros) to the endianness decision part. 

Please note that because of change 1 it can't be compiled with GNU compilers. 