### PR TITLE
Added support for Visual C++ compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ self explanatory.
 The code is written in C++11, as an include-only library (i.e., there is
 nothing you need to build).  There are some provided demo programs and tests
 however.  On a Unix-style system (e.g., Linux, Mac OS X) you should be able
-to just type type
+to just type
 
     make
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ self explanatory.
 The code is written in C++11, as an include-only library (i.e., there is
 nothing you need to build).  There are some provided demo programs and tests
 however.  On a Unix-style system (e.g., Linux, Mac OS X) you should be able
-to just type
+to just type type
 
     make
 

--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -88,6 +88,18 @@
 #include <new>
 #include <stdexcept>
 
+#ifdef _MSC_VER
+    #pragma warning(disable:4146)
+#endif
+
+#ifdef _MSC_VER
+    #define PCG_ALWAYS_INLINE _forceinline
+#elif __GNUC__
+    #define PCG_ALWAYS_INLINE __attribute__((always_inline))
+#else
+    #define PCG_ALWAYS_INLINE inline
+#endif
+
 /*
  * The pcg_extras namespace contains some support code that is likley to
  * be useful for a variety of RNGs, including:
@@ -1204,7 +1216,7 @@ public:
         return baseclass::period_pow2() + table_size*extvalclass::period_pow2();
     }
 
-    __attribute__((always_inline)) result_type operator()()
+    PCG_ALWAYS_INLINE result_type operator()()
     {
         result_type rhs = get_extended_value();
         result_type lhs = this->baseclass::operator()();
@@ -1751,5 +1763,9 @@ typedef pcg_engines::ext_oneseq_xsl_rr_128_64<10,128,false> pcg64_c1024_fast;
 
 typedef pcg_engines::ext_setseq_xsh_rr_64_32<14,16,true>    pcg32_k16384;
 typedef pcg_engines::ext_oneseq_xsh_rs_64_32<14,32,true>    pcg32_k16384_fast;
+
+#ifdef _MSC_VER
+    #pragma warning(default:4146)
+#endif
 
 #endif // PCG_RAND_HPP_INCLUDED

--- a/include/pcg_uint128.hpp
+++ b/include/pcg_uint128.hpp
@@ -63,7 +63,7 @@
         #define PCG_LITTLE_ENDIAN 1
     #elif __BIG_ENDIAN__ || _BIG_ENDIAN
         #define PCG_LITTLE_ENDIAN 0
-    #elif __x86_64 || __x86_64__ || __i386 || __i386__
+    #elif __x86_64 || __x86_64__ || _M_X64 || __i386 || __i386__ || _M_IX86
         #define PCG_LITTLE_ENDIAN 1
     #elif __powerpc__ || __POWERPC__ || __ppc__ || __PPC__ \
           || __m68k__ || __mc68000__


### PR DESCRIPTION
### Corrected Microsoft Visual C++ compilation errors
- **Added support for Visual C++ predefined macros**
The Microsoft Visual C++ compiler doesn't support the predefined macros to identify the CPU architecture `__x86_64`, `__x86_64__`, `__i386`, `__i386__` and uses `_M_X64` and `_M_IX86`. Documented here: https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros.
Without this change is unable to determine target endianness so it doesn't compile.
The Intel C++ Compiler on Windows also uses the macros `_M_X64` and `_M_IX86` instead of `__x86_64`, `__x86_64__`, `__i386`, `__i386__`. Documented in this page: https://software.intel.com/en-us/node/524490.
- **Added support for Visual C++ always inline functions**
Visual C++ doesn't use `__attribute__((always_inline))` and instead uses `__forceinline`. Documented here: https://docs.microsoft.com/en-us/cpp/cpp/inline-functions-cpp#inline-inline-and-forceinline.
- **Corrected Visual C++ C4146 error**
Corrected compilation error on Visual Studio that produced C4146: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146

The code adds support for MSVC++ but doesn't break the compilation with g++ or clang.