### PR TITLE
Fix sequencing violation

### DIFF
--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -1357,7 +1357,9 @@ void extended<table_pow2,advance_pow2,baseclass,extvalclass,kdd>::selfinit()
     //      - any strange correlations would only be apparent if we
     //        were to backstep the generator so that the base generator
     //        was generating the same values again
-    result_type xdiff = baseclass::operator()() - baseclass::operator()();
+    result_type lhs = baseclass::operator()();
+    result_type rhs = baseclass::operator()();
+    result_type xdiff = lhs - rhs;
     for (size_t i = 0; i < table_size; ++i) {
         data_[i] = baseclass::operator()() ^ xdiff;
     }


### PR DESCRIPTION
The operands of binary operators are not sequenced with respect to one another.

Remove the UB by putting them in separate statements (picking the order that the test suite assumes).