### PR TITLE
Use compiler intrinsics when using Microsoft Visual C++

### DIFF
--- a/include/pcg_uint128.hpp
+++ b/include/pcg_uint128.hpp
@@ -92,7 +92,7 @@ namespace pcg_extras {
  *      * trailingzeros         number of trailing zero bits
  */
 
-#ifdef __GNUC__         // Any GNU-compatible compiler supporting C++11 has
+#if defined(__GNUC__)   // Any GNU-compatible compiler supporting C++11 has
                         // some useful intrinsics we can use.
 
 inline bitcount_t flog2(uint32_t v)
@@ -124,6 +124,57 @@ inline bitcount_t trailingzeros(uint64_t v)
     return __builtin_ctzll(v);
 #else
     #error Cannot find a function for uint64_t
+#endif
+}
+
+#elif defined(_MSC_VER)  // Use MSVC++ intrinsics
+
+#include <intrin.h>
+
+#pragma intrinsic(_BitScanReverse, _BitScanForward)
+#if defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)
+#pragma intrinsic(_BitScanReverse64, _BitScanForward64)
+#endif
+
+inline bitcount_t flog2(uint32_t v)
+{
+    unsigned long i;
+    _BitScanReverse(&i, v);
+    return i;
+}
+
+inline bitcount_t trailingzeros(uint32_t v)
+{
+    unsigned long i;
+    _BitScanForward(&i, v);
+    return i;
+}
+
+inline bitcount_t flog2(uint64_t v)
+{
+#if defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)
+    unsigned long i;
+    _BitScanReverse64(&i, v);
+    return i;
+#else
+    // 32-bit x86
+    uint32_t high = v >> 32;
+    uint32_t low  = uint32_t(v);
+    return high ? 32+flog2(high) : flog2(low);
+#endif
+}
+
+inline bitcount_t trailingzeros(uint64_t v)
+{
+#if defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)
+    unsigned long i;
+    _BitScanForward64(&i, v);
+    return i;
+#else
+    // 32-bit x86
+    uint32_t high = v >> 32;
+    uint32_t low  = uint32_t(v);
+    return low ? trailingzeros(low) : trailingzeros(high)+32;
 #endif
 }
 


### PR DESCRIPTION
Uses _BitScanForward and _BitScanReverse, similar to how the gcc path uses __builtin_ctz and __builtin_clz.