### PR TITLE
Bugfix for Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ all:
 	cd test-high; $(MAKE)
 	cd sample; $(MAKE)
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 
 install: all
-	install -m 0644 include/*.hpp $PREFIX/include
+	install -m 0644 include/*.hpp $(PREFIX)/include
 
 test:   all
 	cd test-high; $(MAKE) test


### PR DESCRIPTION
For Ubuntu 16.04 the Prefix needs to be in curly brackets to evaluate it correctly.
The Makefile should be robuster this way.