### PR TITLE
Fix warnings on GCC -wall

### DIFF
--- a/include/pcg_extras.hpp
+++ b/include/pcg_extras.hpp
@@ -626,6 +626,9 @@ private:
 public:
     static constexpr IntType value = fnv(IntType(2166136261U ^ sizeof(IntType)),
                         __DATE__ __TIME__ __FILE__);
+
+    //Prevent creation, while keeping GCC from giving a warning
+    static_arbitrary_seed() = delete;
 };
 
 // Sometimes, when debugging or testing, it's handy to be able print the name

--- a/include/pcg_uint128.hpp
+++ b/include/pcg_uint128.hpp
@@ -101,20 +101,20 @@ namespace pcg_extras {
 
 inline bitcount_t flog2(uint32_t v)
 {
-    return 31 - __builtin_clz(v);
+    return bitcount_t(31 - __builtin_clz(v));
 }
 
 inline bitcount_t trailingzeros(uint32_t v)
 {
-    return __builtin_ctz(v);
+    return bitcount_t(__builtin_ctz(v));
 }
 
 inline bitcount_t flog2(uint64_t v)
 {
 #if UINT64_MAX == ULONG_MAX
-    return 63 - __builtin_clzl(v);
+    return bitcount_t(63 - __builtin_clzl(v));
 #elif UINT64_MAX == ULLONG_MAX
-    return 63 - __builtin_clzll(v);
+    return bitcount_t(63 - __builtin_clzll(v));
 #else
     #error Cannot find a function for uint64_t
 #endif
@@ -123,9 +123,9 @@ inline bitcount_t flog2(uint64_t v)
 inline bitcount_t trailingzeros(uint64_t v)
 {
 #if UINT64_MAX == ULONG_MAX
-    return __builtin_ctzl(v);
+    return bitcount_t(__builtin_ctzl(v));
 #elif UINT64_MAX == ULLONG_MAX
-    return __builtin_ctzll(v);
+    return bitcount_t(__builtin_ctzll(v));
 #else
     #error Cannot find a function for uint64_t
 #endif


### PR DESCRIPTION
Fixes warnings on gcc 9.2. -Wall. I'm assuming static_arbitrary_seed cannot be constructed on purpose, and so my fix keeps things that way, while eliminating -Wctor-dtor-privacy.