### PR TITLE
Remove #include <iostream> to allow compiling for small embedded systems

### DIFF
--- a/include/pcg_extras.hpp
+++ b/include/pcg_extras.hpp
@@ -39,10 +39,8 @@
 #include <cstring>
 #include <cassert>
 #include <limits>
-#include <iostream>
 #include <type_traits>
 #include <utility>
-#include <locale>
 #include <iterator>
 
 #ifdef __GNUC__

--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -80,12 +80,9 @@
 #include <cstring>
 #include <cassert>
 #include <limits>
-#include <iostream>
 #include <iterator>
 #include <type_traits>
 #include <utility>
-#include <locale>
-#include <new>
 #include <stdexcept>
 
 #ifdef _MSC_VER

--- a/sample/codebook.cpp
+++ b/sample/codebook.cpp
@@ -23,10 +23,10 @@
  * Outputs a little spy codebook
  */
 
-#include "pcg_random.hpp"
 #include <cstdio>
 #include <iostream>
 #include <random>
+#include "pcg_random.hpp"
 
 int main()
 {


### PR DESCRIPTION
I'm using the library on a 128kB STM32F4 -processor, and #include <iostream> brings in about 140kB of data, which obviously won't fit in the flash. Without iostream, this library increases code size by about 400 bytes when using pcg32, which is pretty ok (although could probably still be trimmed).

Admittedly it's a bit brute force to just remove the header inclusions, and that it works at all is based on all the iostream -related code being in templates, so that when they're not used there's no problem. If you do use them, you have to include <iostream> yourself and the order does matter (I had to change one of the tests to make them compile).

Another approach would be to merge pull request #4 , switching the extras header to also use forward declarations.

Yet another approach, maybe more robust but less elegant, would be to #ifdef out the iostream headers if some flag (PCG_DONOTUSEIOSTREAM ? ) is defined.

Removing <new> is not absolutely necessary, but I'm not sure what it's used for here, the only relevant part I could find is one use of placement new?