### PR TITLE
Fix portability issues between Clang and Gcc for non-compliant SeedSeq (non-reentrant)

### DIFF
--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -517,10 +517,10 @@ public:
                && !std::is_convertible<SeedSeq, itype>::value
                && !std::is_convertible<SeedSeq, engine>::value,
         can_specify_stream_tag>::type = {})
-        : engine(generate_one<itype,1,2>(seedSeq),
-                 generate_one<itype,0,2>(seedSeq))
     {
-        // Nothing else to do.
+        itype seeddata[2];
+        generate_to<2>(std::forward<SeedSeq>(seedSeq), seeddata);
+        seed(seeddata[1], seeddata[0]);
     }
 
 


### PR DESCRIPTION
This PR addresses issue #67. 
tldr: clang and gcc generates different streams when seeded from another generator on different platforms. 

This is PoC, I am not a template expert in C++, there is probably a nicer way to implement this. 
e.g., I have a redundant parameter `unused` in the newly added constructor 

```cpp
engine(typename sm::stream_state stream_seed, bool unused)
``` 

so it is correctly selected when needed as I had a conflict with 

https://github.com/imneme/pcg-cpp/blob/5b5cac8d61339e810c5dbb4692d868a1d7ca1b2d/include/pcg_random.hpp#L484

This PR uses GNU GCC evaluation order. Thus after merging this PR the stream generates the same result as it generates with GNU GCC.