### PR TITLE
Fix bug in pcg128_t/engine operator>>

### DIFF
--- a/include/pcg_extras.hpp
+++ b/include/pcg_extras.hpp
@@ -175,8 +175,10 @@ operator>>(std::basic_istream<CharT,Traits>& in, pcg128_t& value)
     bool overflow = false;
     for(;;) {
         CharT wide_ch = in.get();
-        if (!in.good())
+        if (!in.good()) {
+            in.clear(std::ios::eofbit);
             break;
+        }
         auto ch = in.narrow(wide_ch, '\0');
         if (ch < '0' || ch > '9') {
             in.unget();

--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -46,7 +46,7 @@
  *            - equality and inequality for RNGs
  *      - and a number of convenience typedefs to mask all the complexity
  *
- * The code employes a fairly heavy level of abstraction, and has to deal
+ * The code employees a fairly heavy level of abstraction, and has to deal
  * with various C++ minutia.  If you're looking to learn about how the PCG
  * scheme works, you're probably best of starting with one of the other
  * codebases (see www.pcg-random.org).  But if you're curious about the
@@ -101,7 +101,7 @@
 #endif
 
 /*
- * The pcg_extras namespace contains some support code that is likley to
+ * The pcg_extras namespace contains some support code that is likely to
  * be useful for a variety of RNGs, including:
  *      - 128-bit int support for platforms where it isn't available natively
  *      - bit twiddling operations
@@ -123,7 +123,7 @@ using namespace pcg_extras;
  *
  *      default_multiplier<uint32_t>::multiplier()
  *
- * gives you the default multipler for 32-bit integers.  We use the name
+ * gives you the default multiplier for 32-bit integers.  We use the name
  * of the constant and not a generic word like value to allow these classes
  * to be used as mixins.
  */
@@ -192,7 +192,7 @@ struct cheap_multiplier<pcg128_t> {
  *                       object, thus every RNG has its own unique sequence
  *
  * This variation is provided though mixin classes which define a function
- * value called increment() that returns the nesessary additive constant.
+ * value called increment() that returns the necessary additive constant.
  */
 
 
@@ -366,7 +366,7 @@ protected:
  * (reducing register pressure).
  *
  * Given the high level of parameterization, the code has to use some
- * template-metaprogramming tricks to handle some of the suble variations
+ * template-metaprogramming tricks to handle some of the subtle variations
  * involved.
  */
 
@@ -1897,7 +1897,7 @@ typedef pcg_engines::ext_oneseq_xsh_rs_64_32<1,32,true>     pcg32_k2_fast;
 // These eight extended RNGs have about as much state as arc4random
 //
 //  - the k variants are k-dimensionally equidistributed
-//  - the c variants offer better crypographic security
+//  - the c variants offer better cryptographic security
 //
 // (just how good the cryptographic security is is an open question)
 
@@ -1920,7 +1920,7 @@ typedef pcg_engines::ext_mcg_xsl_rr_128_64<5,128,false>     pcg64_c32_fast;
 // These eight extended RNGs have more state than the Mersenne twister
 //
 //  - the k variants are k-dimensionally equidistributed
-//  - the c variants offer better crypographic security
+//  - the c variants offer better cryptographic security
 //
 // (just how good the cryptographic security is is an open question)
 


### PR DESCRIPTION
Consider the following example where we attempt to extract and insert a `pcg64` engine with a stream.

```
#include <iostream>
#include <sstream>

#include "pcg_random.hpp"

int main() {
    pcg64 g1, g2;

    g1.discard(100); // Arbitrarily advance the state

    std::stringstream ss;
    ss << g1;
    ss >> g2;

    std::cout << g1 << std::endl;
    std::cout << g2 << std::endl;
}
```
The expected output is two identical chunks, however, the following is produced with `g2` having the default state value.
```
47026247687942121848144207491837523525 117397592171526113268558934119004209487 331463646335672436028301991658809050663
47026247687942121848144207491837523525 117397592171526113268558934119004209487 245720598905631564143578724636268694099
```
The issue is caused by the `pcg128_t::operator>>` which uses the `std::basic_istream::get` function to read each character of the input stream. This [function](https://en.cppreference.com/w/cpp/io/basic_istream/get), "Reads one character and returns it if available. Otherwise, returns `Traits::eof()` and sets `failbit` and `eofbit`." Thus, the `failbit` is set if it reaches the end of the stream. The `engine::operator>>` only updates the state if `!in.fail()` which will not occur if this bit is set. The change we propose sets the state to only contain the `eofbit`. We also fix a few spelling mistakes in comments.
