### PR TITLE
Fix reversed oneseq and mcg / fast pcg32_k64 typedefs

### DIFF
--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -1902,8 +1902,8 @@ typedef pcg_engines::ext_oneseq_xsh_rs_64_32<1,32,true>     pcg32_k2_fast;
 // (neither is intended for use in cryptographic applications)
 
 typedef pcg_engines::ext_setseq_xsh_rr_64_32<6,16,true>     pcg32_k64;
-typedef pcg_engines::ext_mcg_xsh_rs_64_32<6,32,true>        pcg32_k64_oneseq;
-typedef pcg_engines::ext_oneseq_xsh_rs_64_32<6,32,true>     pcg32_k64_fast;
+typedef pcg_engines::ext_oneseq_xsh_rs_64_32<6,32,true>     pcg32_k64_oneseq;
+typedef pcg_engines::ext_mcg_xsh_rs_64_32<6,32,true>        pcg32_k64_fast;
 
 typedef pcg_engines::ext_setseq_xsh_rr_64_32<6,16,false>    pcg32_c64;
 typedef pcg_engines::ext_oneseq_xsh_rs_64_32<6,32,false>    pcg32_c64_oneseq;


### PR DESCRIPTION
I noticed this typo while trying to better understand the extension method. Seems like a pretty simple fix.