### PR TITLE
Optimized unxorshift

### DIFF
--- a/include/pcg_extras.hpp
+++ b/include/pcg_extras.hpp
@@ -263,21 +263,11 @@ inline std::istream& operator>>(std::istream& in, uint8_t& value)
 template <typename itype>
 inline itype unxorshift(itype x, bitcount_t bits, bitcount_t shift)
 {
-    if (2*shift >= bits) {
-        return x ^ (x >> shift);
-    }
-    itype lowmask1 = (itype(1U) << (bits - shift*2)) - 1;
-    itype highmask1 = ~lowmask1;
-    itype top1 = x;
-    itype bottom1 = x & lowmask1;
-    top1 ^= top1 >> shift;
-    top1 &= highmask1;
-    x = top1 | bottom1;
-    itype lowmask2 = (itype(1U) << (bits - shift)) - 1;
-    itype bottom2 = x & lowmask2;
-    bottom2 = unxorshift(bottom2, bits - shift, shift);
-    bottom2 &= lowmask1;
-    return top1 | bottom2;
+    do {
+        x ^= x >> shift;
+        shift *= 2u;
+    } while(shift < bits);
+    return x;
 }
 
 /*


### PR DESCRIPTION
I was looking through how you implemented unxorshift, and noticed it seems over-complicated and could be optimized using a clever implementation.

The current implementation un-xorshifts the value `shift` bits at a time. The idea there is clear: only the first `shift` bits are unaffected by the xorshift, so you first use those to recover the next `shift` bits, which are used to recover the next `shift` bits, etc. The current implementation chose to implement this repeat recursively instead of iteratively for some reason, which may be less optimal if the compiler doesn't optimize it (which it is less likely to do since it's not tail recursion).

My implementation makes use of the fact that if `y = x ^ (x >> c)`, then `y ^ (y >> c) = x ^ (x >> 2c)`:
```
  y ^ (y >> c)
= (x ^ (x >> c)) ^ ((x ^ (x >> c)) >> c)
= x ^ (x >> c) ^ (x >> c) ^ (x >> 2c)
= x ^ (x >> 2c)
```

This allows for a simple recursive step: `unxorshift(x, bits, shift) -> unxorshift(x ^ (x >> shift), bits, shift * 2)`. Since this is tail recursion, this can be trivially optimized as an iterative solution, which I went ahead and did manually in this PR (since it was pretty simple to do). I could have implemented it as a for loop, but since the initial loop condition check is unnecessary given the precondition `shift < bits`, implementing it with a do-while loop removes a conditional jump from the compiled assembly.

This new implementation also scales better with larger input sizes. The current implementation recurses `ceil(bits / shift - 1)` times, which, assuming a constant value for `shift`, is linear. My implementation loops `ceil(log_2(bits / shift))` times, which is logarithmic.

You can see just how much this optimizes the implementation by comparing the resulting assembly code (shown for 32-bit values): https://godbolt.org/z/E64G7vq83 (Using Clang because GCC does some optimizations that make the comparison look worse than it is).