### PR TITLE
Make result_type typedef in pcg_extras::seed_seq_from public

### DIFF
--- a/include/pcg_extras.hpp
+++ b/include/pcg_extras.hpp
@@ -583,9 +583,9 @@ class seed_seq_from {
 private:
     RngType rng_;
 
+public:
     typedef uint_least32_t result_type;
 
-public:
     template<typename... Args>
     seed_seq_from(Args&&... args) :
         rng_(std::forward<Args>(args)...)

--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -333,7 +333,7 @@ public:
 
     void set_stream(itype specific_seq)
     {
-         inc_ = (specific_seq << 1) | 1;
+         inc_ = (specific_seq << 1) | static_cast<itype>(1u);
     }
 
     static constexpr bool can_specify_stream = true;
@@ -1864,16 +1864,24 @@ using ext_setseq_xsl_rr_128_64 =
 } // namespace pcg_engines
 
 typedef pcg_engines::setseq_xsh_rr_64_32        pcg32;
-typedef pcg_engines::setseq_dxsm_64_32          pcg32_dxsm;
 typedef pcg_engines::oneseq_xsh_rr_64_32        pcg32_oneseq;
 typedef pcg_engines::unique_xsh_rr_64_32        pcg32_unique;
 typedef pcg_engines::mcg_xsh_rs_64_32           pcg32_fast;
 
+typedef pcg_engines::setseq_dxsm_64_32          pcg32_dxsm;
+typedef pcg_engines::oneseq_dxsm_64_32          pcg32_dxsm_oneseq;
+typedef pcg_engines::unique_dxsm_64_32          pcg32_dxsm_unique;
+typedef pcg_engines::mcg_dxsm_64_32             pcg32_dxsm_fast;
+
 typedef pcg_engines::setseq_xsl_rr_128_64       pcg64;
-typedef pcg_engines::setseq_dxsm_128_64         pcg64_dxsm;
 typedef pcg_engines::oneseq_xsl_rr_128_64       pcg64_oneseq;
 typedef pcg_engines::unique_xsl_rr_128_64       pcg64_unique;
 typedef pcg_engines::mcg_xsl_rr_128_64          pcg64_fast;
+
+typedef pcg_engines::setseq_dxsm_128_64         pcg64_dxsm;
+typedef pcg_engines::oneseq_dxsm_128_64         pcg64_dxsm_oneseq;
+typedef pcg_engines::unique_dxsm_128_64         pcg64_dxsm_unique;
+typedef pcg_engines::mcg_dxsm_128_64            pcg64_dxsm_fast;
 
 typedef pcg_engines::setseq_rxs_m_xs_8_8        pcg8_once_insecure;
 typedef pcg_engines::setseq_rxs_m_xs_16_16      pcg16_once_insecure;
@@ -1904,8 +1912,8 @@ typedef pcg_engines::ext_oneseq_xsh_rs_64_32<1,32,true>     pcg32_k2_fast;
 // (neither is intended for use in cryptographic applications)
 
 typedef pcg_engines::ext_setseq_xsh_rr_64_32<6,16,true>     pcg32_k64;
-typedef pcg_engines::ext_mcg_xsh_rs_64_32<6,32,true>        pcg32_k64_oneseq;
-typedef pcg_engines::ext_oneseq_xsh_rs_64_32<6,32,true>     pcg32_k64_fast;
+typedef pcg_engines::ext_oneseq_xsh_rs_64_32<6,32,true>     pcg32_k64_oneseq;
+typedef pcg_engines::ext_mcg_xsh_rs_64_32<6,32,true>        pcg32_k64_fast;
 
 typedef pcg_engines::ext_setseq_xsh_rr_64_32<6,16,false>    pcg32_c64;
 typedef pcg_engines::ext_oneseq_xsh_rs_64_32<6,32,false>    pcg32_c64_oneseq;

--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -1864,11 +1864,13 @@ using ext_setseq_xsl_rr_128_64 =
 } // namespace pcg_engines
 
 typedef pcg_engines::setseq_xsh_rr_64_32        pcg32;
+typedef pcg_engines::setseq_dxsm_64_32          pcg32_dxsm;
 typedef pcg_engines::oneseq_xsh_rr_64_32        pcg32_oneseq;
 typedef pcg_engines::unique_xsh_rr_64_32        pcg32_unique;
 typedef pcg_engines::mcg_xsh_rs_64_32           pcg32_fast;
 
 typedef pcg_engines::setseq_xsl_rr_128_64       pcg64;
+typedef pcg_engines::setseq_dxsm_128_64         pcg64_dxsm;
 typedef pcg_engines::oneseq_xsl_rr_128_64       pcg64_oneseq;
 typedef pcg_engines::unique_xsl_rr_128_64       pcg64_unique;
 typedef pcg_engines::mcg_xsl_rr_128_64          pcg64_fast;


### PR DESCRIPTION
Unless I'm somehow misunderstanding how `pcg_extras::seed_seq_from` is supposed to be used, I believe the `result_type` typedef in `pcg_extras::seed_seq_from` should be public instead of private. Otherwise, when trying to use `pcg_extras::seed_seq_from` with standard library PRNGs (say `std::mt19937`), compilation fails (for both gcc 12.1.0 and clang 14.0.0) due to the aforementioned typedef being private.

A simple example demonstrating the problem:
```
#include <random>
#include "PCG/pcg_random.hpp"
#include "PCG/pcg_extras.hpp"

int main()
{
    pcg_extras::seed_seq_from<std::random_device> seed_source;

    pcg64        pcg_generator(seed_source); // This works
    std::mt19937 mt_generator(seed_source);  // This does not
    return 0;
}
```
After the change, the program compiles without problems.