### PR TITLE
Fix MSVC errors in operator>>

### DIFF
--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -333,7 +333,7 @@ public:
 
     void set_stream(itype specific_seq)
     {
-         inc_ = (specific_seq << 1) | 1;
+         inc_ = (specific_seq << 1) | itype(1U);
     }
 
     static constexpr bool can_specify_stream = true;
@@ -618,7 +618,7 @@ operator>>(std::basic_istream<CharT,Traits>& in,
 
     if (!in.fail()) {
         bool good = true;
-        if (multiplier != rng.multiplier()) {
+        if (multiplier != itype(rng.multiplier())) {
            good = false;
         } else if (rng.can_specify_stream) {
            rng.set_stream(increment >> 1);


### PR DESCRIPTION
Hi,

I've found these two compiler errors while trying to use `operator>>` with `pcg_engines::cm_setseq_dxsm_128_64` on MSVC. The extra casts resolve the errors.

```
include\pcg_random.hpp(621,13): error C2678: binary '!=': no operator found which takes a left-hand operand of type 'pcg_extras::pcg128_t' (or there is no acceptable conversion)
include\pcg_random.hpp(336,34): error C2678: binary '|': no operator found which takes a left-hand operand of type 'pcg_extras::uint_x4<uint32_t,uint64_t>' (or there is no acceptable conversion)
```

Kind regards,
Bram