### PR TITLE
Use consistent integer type

### DIFF
--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -333,7 +333,7 @@ public:
 
     void set_stream(itype specific_seq)
     {
-         inc_ = (specific_seq << 1) | 1;
+         inc_ = (specific_seq << 1) | itype(1U);
     }
 
     static constexpr bool can_specify_stream = true;


### PR DESCRIPTION
There is no `pcg128_t | int` defined if `__uint128_t` is not available.

c.f. https://github.com/daqana/dqrng/issues/88