### PR TITLE
Fix set_stream to use unsigned integer for inc_; Workaround for Windo…

### DIFF
--- a/include/pcg_random.hpp
+++ b/include/pcg_random.hpp
@@ -333,7 +333,7 @@ public:
 
     void set_stream(itype specific_seq)
     {
-         inc_ = (specific_seq << 1) | 1;
+         inc_ = (specific_seq << 1) | itype(1U);
     }
 
     static constexpr bool can_specify_stream = true;


### PR DESCRIPTION
…ws SDK header conflicts in pcg-cpp

The build was failing on Windows (MSVC) with error C2678 due to  ambiguous 'operator|' calls. 

Root cause: Windows SDK headers (winuser.h, winnt.h, etc.) define  multiple operator| overloads for various enums. When using a literal  integer '1' with pcg_extras types, the compiler cannot distinguish  between PCG's custom operators and Windows' enum operators.

Solution: Explicitly cast the literal to 'itype' to resolve the  ambiguity. This ensures the compiler selects the correct operator  defined in pcg-cpp while maintaining full cross-platform compatibility  for Linux and macOS.